### PR TITLE
Fix local constant value

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -30,7 +30,7 @@ get_velocity()
 
     # Consts
     local THOUSAND=1000
-    local MILLION=100000
+    local MILLION=1000000
 
     local vel=$(( new_value - old_value ))
     local velKB=$(( vel / THOUSAND ))


### PR DESCRIPTION
Isn't the value of `MILLION` with six `0`s instead of five?
