### PR TITLE
Fix for non-standard bash locations (NixOS)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/scripts/helpers.sh"

--- a/net_speed.tmux
+++ b/net_speed.tmux
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/scripts/helpers.sh"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 for testSuite in $CURRENT_DIR/tests/suites/* ; do

--- a/scripts/download_speed.sh
+++ b/scripts/download_speed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 
 ##
 # Varialbes

--- a/scripts/net_speed.sh
+++ b/scripts/net_speed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"

--- a/scripts/upload_speed.sh
+++ b/scripts/upload_speed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"

--- a/tests/suites/helpers.test.sh
+++ b/tests/suites/helpers.test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS="$CURRENT_DIR/../../scripts"

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 ###############################################################################
 # Author: Travis Goldie
 # Purpose: Util funcs for unit tests


### PR DESCRIPTION
This fixes *tmux-net-speed* to work on systems with a non-standard bash installation location. For example: NixOS. It uses `#!/usr/bin/env bash` at the start of all the shell scripts instead of hard coding the bash location.

Other tmux plugins use this and worked out of the box.