### PR TITLE
Cache results to prevent miscalculations

### DIFF
--- a/scripts/download_speed.sh
+++ b/scripts/download_speed.sh
@@ -12,13 +12,19 @@ sum_download_speed()
 main()
 {
     # TODO make configurable
-    #local file=$(get_tmux_option $DOWNLOAD_FILE)
-    local file=$DOWNLOAD_FILE
-    local old_val=$(read_file $file)
-    local new_val=$(sum_download_speed)
+    if ! is_update_needed $DOWNLOAD_TIME_FILE; then
+        local vel=$(read_file $DOWNLOAD_CACHE_FILE)
+    else
+        local file=$DOWNLOAD_FILE
+        local old_val=$(read_file $file)
+        local new_val=$(sum_download_speed)
 
-    write_file $file $new_val
-    local vel=$(get_velocity $new_val $old_val)
+        write_file $file $new_val
+        local vel=$(get_velocity $new_val $old_val)
+
+        write_file $DOWNLOAD_TIME_FILE $(date +%s)
+        write_file $DOWNLOAD_CACHE_FILE "$vel"
+    fi
 
     ## Format output
     local format=$(get_tmux_option @download_speed_format "%s")

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -5,6 +5,10 @@
 ##
 DOWNLOAD_FILE="/tmp/tmux_net_speed.download"
 UPLOAD_FILE="/tmp/tmux_net_speed.upload"
+DOWNLOAD_CACHE_FILE="/tmp/tmux_net_speed.download.cache"
+UPLOAD_CACHE_FILE="/tmp/tmux_net_speed.upload.cache"
+DOWNLOAD_TIME_FILE="/tmp/tmux_net_speed.download.time"
+UPLOAD_TIME_FILE="/tmp/tmux_net_speed.upload.time"
 
 get_tmux_option() {
     local option=$1
@@ -22,6 +26,19 @@ set_tmux_option() {
     local option=$1
     local value=$2
     tmux set-option -gq "$option" "$value"
+}
+
+is_update_needed()
+{
+    local update_file=$1
+
+    local interval=$(get_tmux_option 'status-interval' 5)
+    local update_time=$(read_file $update_file)
+    local cur_time=$(date +%s)
+    if [ $((update_time + interval)) -gt $cur_time ]; then
+        return 1;
+    fi;
+    return 0;
 }
 
 get_velocity()

--- a/scripts/upload_speed.sh
+++ b/scripts/upload_speed.sh
@@ -13,12 +13,19 @@ main()
 {
     # TODO make configurable
     #local upload_file=$(get_tmux_option $UPLOAD_FILE)
-    local file=$UPLOAD_FILE
-    local old_val=$(read_file $file)
-    local new_val=$(sum_upload_speed)
+    if ! is_update_needed $UPLOAD_TIME_FILE; then
+        local vel=$(read_file $UPLOAD_CACHE_FILE)
+    else
+        local file=$UPLOAD_FILE
+        local old_val=$(read_file $file)
+        local new_val=$(sum_upload_speed)
 
-    write_file $file $new_val
-    local vel=$(get_velocity $new_val $old_val)
+        write_file $file $new_val
+        local vel=$(get_velocity $new_val $old_val)
+
+        write_file $UPLOAD_TIME_FILE $(date +%s)
+        write_file $UPLOAD_CACHE_FILE "$vel"
+    fi
 
     ## Format output
     local format=$(get_tmux_option @upload_speed_format "%s")


### PR DESCRIPTION
The code assumes that the status bar will only be updated every
status-interval seconds

In practice status-interval is a maximum value, not a minimum value. So
if the status bar is actually updated every second even though the
configuration is for 5 seconds all of the calculations are off and the
bitrate will be calculated as a fifth of the real rate.

See https://github.com/tmux-plugins/tmux-cpu/issues/15 for a similar
issue with a different plugin, except that here it is much worse because
it actually leads to a WRONG RESULT and not just a faster update. This
commit implements @BrainMaestro 's suggestion from that thread.

Has some file spam for keeping track of everything needed but I'm only adding to an existing problem.